### PR TITLE
Fixes for arch kde

### DIFF
--- a/distro/arch.py
+++ b/distro/arch.py
@@ -42,8 +42,13 @@ def config(de_name: str, distro_version: str, username: str, root_partuuid: str,
             chroot("systemctl enable gdm.service")
         case "kde":
             print_status("Installing KDE")
-            chroot("pacman -S --noconfirm plasma-meta plasma-wayland-session kde-applications packagekit-qt5")
+            chroot("pacman -S --noconfirm plasma-meta plasma-wayland-session kde-system-meta kde-utilities-meta packagekit-qt5")
             chroot("systemctl enable sddm.service")
+            # KDE theme for sddm
+            mkdir("/mnt/depthboot/etc/sddm.conf.d")
+            with open("/mnt/depthboot/etc/sddm.conf.d/breeze-theme.conf") as conf:
+                conf.write("[Theme]
+                           Current=breeze")
         case "xfce":
             print_status("Installing Xfce")
             # no wayland support in xfce

--- a/distro/arch.py
+++ b/distro/arch.py
@@ -46,9 +46,8 @@ def config(de_name: str, distro_version: str, username: str, root_partuuid: str,
             chroot("systemctl enable sddm.service")
             # KDE theme for sddm
             mkdir("/mnt/depthboot/etc/sddm.conf.d")
-            with open("/mnt/depthboot/etc/sddm.conf.d/breeze-theme.conf") as conf:
-                conf.write("[Theme]
-                           Current=breeze")
+            with open("/mnt/depthboot/etc/sddm.conf.d/breeze-theme.conf", "a") as conf:
+                conf.write("[Theme]\nCurrent=breeze")
         case "xfce":
             print_status("Installing Xfce")
             # no wayland support in xfce


### PR DESCRIPTION
The kde-applications group installs a lot of unneeded packages. Instead kde-system-meta and kde-utilities-meta are used. This also sets the default sddm theme to breeze.