### PR TITLE
Add Ubuntu 23.04

### DIFF
--- a/.github/scripts/combine_sizes.py
+++ b/.github/scripts/combine_sizes.py
@@ -45,7 +45,7 @@ if __name__ == "__main__":
 
     # Calculate average sizes for distros with multiple versions
     all_sizes["ubuntu_average"] = round(
-        (all_sizes["ubuntu_22.04"]["cli"] + all_sizes["ubuntu_22.10"]["cli"]) / 2, 1)
+        (all_sizes["ubuntu_22.04"]["cli"] + all_sizes["ubuntu_23.04"]["cli"]) / 2, 1)
     all_sizes["fedora_average"] = round((all_sizes["fedora_38"]["cli"] + all_sizes["fedora_39"]["cli"]) / 2, 1)
 
     with open("os_sizes.json", "w") as f:

--- a/.github/workflows/test-builds.yml
+++ b/.github/workflows/test-builds.yml
@@ -12,7 +12,7 @@ jobs:
   test-ubuntu:
     strategy:
       matrix:
-        version: [ "22.04", "22.10" ]
+        version: [ "22.04", "23.04" ]
         de_name: [ "gnome", "kde", "xfce", "lxqt", "budgie", "deepin", "cinnamon", "cli" ]
     runs-on: ubuntu-latest
     steps:

--- a/cli_input.py
+++ b/cli_input.py
@@ -42,9 +42,9 @@ def get_user_input(verbose_kernel: bool, skip_device: bool = False) -> dict:
             case "Ubuntu":
                 output_dict["distro_name"] = "ubuntu"
                 output_dict["distro_version"] = ia_selection("Which Ubuntu version would you like to use?",
-                                                             options=["22.04", "22.10"], flags=[
+                                                             options=["22.04", "23.04"], flags=[
                         f"{os_sizes['ubuntu_22.04']['cli']}GB (LTS version)",
-                        f"{os_sizes['ubuntu_22.10']['cli']}GB (latest)"])
+                        f"{os_sizes['ubuntu_23.04']['cli']}GB (latest)"])
                 break
             case "Arch":
                 output_dict["distro_name"] = "arch"

--- a/distro/ubuntu.py
+++ b/distro/ubuntu.py
@@ -13,7 +13,8 @@ def config(de_name: str, distro_version: str, verbose: bool, kernel_version: str
         "20.04": "focal",
         "21.04": "hirsute",
         "22.04": "jammy",
-        "22.10": "kinetic"
+        "22.10": "kinetic",
+        "23.04": "lunar"
     }
     # add missing apt sources
     with open("/mnt/depthboot/etc/apt/sources.list", "a") as file:

--- a/os_sizes.json
+++ b/os_sizes.json
@@ -42,7 +42,7 @@
     "lxqt": 4.7,
     "xfce": 5.1
   },
-  "ubuntu_22.10": {
+  "ubuntu_23.04": {
     "budgie": 5.4,
     "cinnamon": 7.0,
     "cli": 3.7,

--- a/os_sizes.json
+++ b/os_sizes.json
@@ -42,7 +42,7 @@
     "lxqt": 4.7,
     "xfce": 5.1
   },
-  "ubuntu_23.04": {
+  "ubuntu_22.10": {
     "budgie": 5.4,
     "cinnamon": 7.0,
     "cli": 3.7,


### PR DESCRIPTION
This pull request removes Ubuntu 22.10 and adds Ubuntu 23.04. This pull request should be accepted after [apt-repo](https://github.com/eupnea-linux/apt-repo) adds lunar support and after my pull request in [ubuntu-rootfs](https://github.com/eupnea-linux/ubuntu-rootfs/pull/1) is accepted.