### PR TITLE
gitignore all __pycache__ dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 /.idea/
 depthboot.img
 kernel.flags
-/__pycache__/
+__pycache__
 /venv/


### PR DESCRIPTION
A `/distro/__pycache__` folder got generated so I added it to .gitignore
![image](https://github.com/eupnea-linux/depthboot-builder/assets/52586855/7292cf18-3faf-45f0-869f-6f6048bcc842)
