### PR TITLE
Add fix for jinlon keyboard scan codes

### DIFF
--- a/build.py
+++ b/build.py
@@ -328,6 +328,11 @@ def post_extract(build_options) -> None:
         print_status("Fixing screen rotation")
         # Install hwdb file to fix auto rotate being flipped on some devices
         cpfile("configs/hwdb/61-sensor.hwdb", "/mnt/depthboot/etc/udev/hwdb.d/61-sensor.hwdb")
+
+        # Install hwdb file to fix keys doing the wrong actions on jinlon
+        cpfile("configs/hwdb/90-custom-keyboard.hwdb", "/mnt/depthboot/etc/udev/hwdb.d/90-custom-keyboard.hwdb")
+
+        # Compile hwdb with the new .hwdb files
         chroot("systemd-hwdb update")
 
         print_status("Cleaning /boot")

--- a/configs/hwdb/90-custom-keyboard.hwdb
+++ b/configs/hwdb/90-custom-keyboard.hwdb
@@ -1,0 +1,3 @@
+evdev:atkbd:dmi:bvn*:bvr*:bd*:svn*:pnJinlon:pvr*
+ KEYBOARD_KEY_97=!kbdillumdown
+ KEYBOARD_KEY_92=scale


### PR DESCRIPTION
- I haven't tested it yet
- It might make more sense to name the file `60-keyboard.hwdb` instead. I'm not sure